### PR TITLE
Run against Jan 2026 VFIToolkit

### DIFF
--- a/CastanedaDiazGimenezRiosRull2003/CastanedaDiazGimenezRiosRull2003.m
+++ b/CastanedaDiazGimenezRiosRull2003/CastanedaDiazGimenezRiosRull2003.m
@@ -311,7 +311,7 @@ FnsToEvaluate3.K=FnsToEvaluate.K;
 simoptions.transprobs={'L','K'};
 simoptions.timehorizons=5; % 5 period transitions
 simoptions.transprobquantiles=5; % number of quantiles to use when calculating transition probabilities
-CorrTransProbs=EvalFnOnAgentDist_CorrTransProbs_InfHorz(StationaryDist,Policy,FnsToEvaluate3,Params,[],n_d,n_a,n_z,d_grid,a_grid,z_grid,pi_z,simoptions);
+CorrTransProbs=EvalFnOnAgentDist_AutoCorrTransProbs_InfHorz(StationaryDist,Policy,FnsToEvaluate3,Params,[],n_d,n_a,n_z,d_grid,a_grid,z_grid,pi_z,simoptions);
 
 Table9variables=zeros(2,5,'gpuArray');
 for ii=1:5
@@ -336,7 +336,7 @@ fprintf(FID, 'United States  & 0.67  & 0.47  &  0.45 & 0.50  & 0.71  \\\\ \n');
 fprintf(FID, 'Benchmark      & %8.2f & %8.2f & %8.2f & %8.2f & %8.2f \\\\ \n', Table9variables(2,:));
 fprintf(FID, '\\hline \n \\end{tabular*} \n');
 fprintf(FID, '\\begin{minipage}[t]{1.00\\textwidth}{\\baselineskip=.5\\baselineskip \\vspace{.3cm} \\footnotesize{ \n');
-fprintf(FID, 'Note: Based on %d simulations. \\\\ \n', NSims);
+fprintf(FID, 'Note: Based on %d simulations. \\\\ \n', NSimulations);
 fprintf(FID, '}} \\end{minipage}');
 fclose(FID);
 

--- a/TestTheReplications.m
+++ b/TestTheReplications.m
@@ -1,0 +1,25 @@
+% Run to test all the Life-Cycle Models are working without error.
+
+clear all
+addpath('./Aiyagari1994/')
+cd Aiyagari1994
+mkdir SavedOutput\
+mkdir SavedOutput\LatexInputs\
+mkdir SavedOutput\Graphs\
+Aiyagari1994
+cd ..
+
+clear all
+addpath('./CastanedaDiazGimenezRiosRull2003/')
+cd CastanedaDiazGimenezRiosRull2003
+mkdir SavedOutput\
+mkdir SavedOutput\LatexInputs\
+CastanedaDiazGimenezRiosRull2003
+cd ..
+
+clear all
+addpath('./GuerrieriLorenzoni2017/')
+cd GuerrieriLorenzoni2017
+mkdir SavedOutput\
+mkdir SavedOutput\LatexInputs\
+GuerrieriLorenzoni2017


### PR DESCRIPTION
Changes that mostly get replicates running with the toolkit.  This PR is marked as draft because it's not 100% working.

There's a bit of a difference between running and working.  I'm suspect of the answers these replications give, so please check.

Late in the run `CastanedaDiazGimenezRiosRull2003` calls a non-existent `CalibrateFromModelTargetsFn`

The first GE solution converges in `GuerrieriLorenzoni2017` but the second seems to miss the solution.  There's a working version of this program (updated to be sure) in the `VFI-toolkit-examples` repository.  There are probably some answers there to explain how to true up the replication version.