### PR TITLE
Update CDGRR2003

### DIFF
--- a/CastanedaDiazGimenezRiosRull2003/CDGRR2003_RatioEarningsOldYoung.m
+++ b/CastanedaDiazGimenezRiosRull2003/CDGRR2003_RatioEarningsOldYoung.m
@@ -77,19 +77,19 @@ parfor i=1:K*Nsim
     for t=2:20
         if s_c>J %Check that they are still working
             TheyRetired=1; %If not working mark them as having retired.
+            break
         else
             d2_c=Policy(2,a_c,s_c);
             a_c=d2_c; %a_c=Phi_aprimeKron(d1_c,s_c,new_s_c); %Actually, can ignore the estate tax, since we are only looking at people who don't retire (and so cannot die) anyway
             [~,s_c]=max(cumsumpi_s(s_c,:)>rand(1,1));
             YoungEarnings(t)=e(s_c)*d_grid(Policy(1,a_c,s_c))*w;
         end
-        
     end
     if TheyRetired==0
         for t=21:30
-            
             if s_c>J %Check that they are still working
                 TheyRetired=1; %If not working mark them as having retired.
+                break
             else
                 d2_c=Policy(2,a_c,s_c);
                 a_c=d2_c; %a_c=Phi_aprimeKron(d1_c,s_c,new_s_c); %Actually, can ignore the estate tax, since we are only looking at people who don't retire (and so cannot die) anyway

--- a/CastanedaDiazGimenezRiosRull2003/CastanedaDiazGimenezRiosRull2003.m
+++ b/CastanedaDiazGimenezRiosRull2003/CastanedaDiazGimenezRiosRull2003.m
@@ -520,6 +520,8 @@ ModelTargetsFn=@(Params) CDGRR2003_ModelTargetsFn(Params, n_d,n_a,n_z,a_grid,Ret
 % ModelTargets must also contain the model values for any General Equilibrium conditions.
 GeneralEqmTargetNames={'GE_InterestRate','GE_GovBudgetBalance'};
 
+return; % We return here because the following code references interfaces that no longer exist in the current library
+
 %% Do the actual calibration
 
 [Params1,fval,counteval,exitflag]=CalibrateFromModelTargetsFn(Params, ParamNamesToEstimate, EstimationTargets, ModelTargetsFn, estimationoptions, GEPriceParamNames, GeneralEqmTargetNames);


### PR DESCRIPTION
Update CDGRR2003 so that it does not fail due to deletion of calibration functions from the VFIToolkit-matlab library. Also, when computing ratios of Young and Old earnings, we can use a break statement to break out of the loop once the simulated subject retires.  This saves 10% of the execution time of this loop, which saves nearly a minute when doing 1m simulations (as we do).